### PR TITLE
Expanded force powers level 2 and 3 text

### DIFF
--- a/Collections/SW5E Things/power gvars/6269cf7a-0df9-4789-992c-29dbc20ac053.json
+++ b/Collections/SW5E Things/power gvars/6269cf7a-0df9-4789-992c-29dbc20ac053.json
@@ -1403,5 +1403,70 @@
         "name": "Transfer Force",
         "level": 2,
         "classes": "Dark Side Power"
+    },
+    {
+        "name": "Aura of Vitality",
+        "level": 3,
+        "classes": "Light Side Power"
+    },
+    {
+        "name": "Disruption",
+        "level": 3,
+        "classes": "Light Side Power"
+    },
+    {
+        "name": "Farseeing",
+        "level": 3,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Force Concurrence",
+        "level": 3,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Force Stealth",
+        "level": 3,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Greater Tapas",
+        "level": 3,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Hatred",
+        "level": 3,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Lesser Whirlwind",
+        "level": 3,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Lightning Discharge",
+        "level": 3,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Moment Reading",
+        "level": 3,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Steal Knowledge",
+        "level": 3,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Sustaining Meditation",
+        "level": 3,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Telekinetic Wall",
+        "level": 3,
+        "classes": "Universal Power"
     }
 ]

--- a/Collections/SW5E Things/power gvars/6269cf7a-0df9-4789-992c-29dbc20ac053.json
+++ b/Collections/SW5E Things/power gvars/6269cf7a-0df9-4789-992c-29dbc20ac053.json
@@ -1318,5 +1318,90 @@
         "name": "Wrathful Blow",
         "level": 1,
         "classes": "Dark Side Power"
+    },
+    {
+        "name": "Channel Pain",
+        "level": 2,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Control Force",
+        "level": 2,
+        "classes": "Light Side Power"
+    },
+    {
+        "name": "Force Grip",
+        "level": 2,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Force Lift",
+        "level": 2,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Force Listening",
+        "level": 2,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Force Thrust",
+        "level": 2,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Forked Lightning",
+        "level": 2,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Freedom of Will",
+        "level": 2,
+        "classes": "Light Side Power"
+    },
+    {
+        "name": "Healing Meditation",
+        "level": 2,
+        "classes": "Light Side Power"
+    },
+    {
+        "name": "Lightning Surge",
+        "level": 2,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Mass Dun Moch",
+        "level": 2,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Mass Mind Trick",
+        "level": 2,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Mind Whip",
+        "level": 2,
+        "classes": "Dark Side Power"
+    },
+    {
+        "name": "Preservation",
+        "level": 2,
+        "classes": "Light Side Power"
+    },
+    {
+        "name": "Respite",
+        "level": 2,
+        "classes": "Light Side Power"
+    },
+    {
+        "name": "Skill Proficiency",
+        "level": 2,
+        "classes": "Universal Power"
+    },
+    {
+        "name": "Transfer Force",
+        "level": 2,
+        "classes": "Dark Side Power"
     }
 ]

--- a/Homebrew/Resolute Spellbook/firstdaybreak-additions
+++ b/Homebrew/Resolute Spellbook/firstdaybreak-additions
@@ -373,4 +373,23 @@
     "ritual": false,
     "description": "The next time you hit with a melee weapon attack during this power’s duration, your attack deals an extra 1d6 psychic damage. Additionally, if the target is not a droid or construct, it must make a Wisdom saving throw or be frightened of you until the power ends. As an action, the creature can make a Wisdom check against your force save DC to steel its resolve and end this power.",
     "concentration": true
-  }
+  },
+  {
+    "name": "Channel Pain",
+    "level": 2,
+    "school": "Force",
+    "classes": "Dark",
+    "subclasses": "",
+    "casttime": "1 bonus action",
+    "range": "Self",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "Concentration, up to 1 minute",
+    "ritual": false,
+    "description": "You draw power from your pain. If you have taken 15 or more damage since the end of your last turn, you gain advantage on melee attack rolls and saving throws. Damage to temporary hit points is not included in this calculation. This benefit lasts until the start of your next turn. For the duration of the power, if you start your turn having taken 15 points of damage since the end of your last turn, you will get the bonus again.",
+    "concentration": true
+  },
+

--- a/Homebrew/Resolute Spellbook/firstdaybreak-additions
+++ b/Homebrew/Resolute Spellbook/firstdaybreak-additions
@@ -392,4 +392,59 @@
     "description": "You draw power from your pain. If you have taken 15 or more damage since the end of your last turn, you gain advantage on melee attack rolls and saving throws. Damage to temporary hit points is not included in this calculation. This benefit lasts until the start of your next turn. For the duration of the power, if you start your turn having taken 15 points of damage since the end of your last turn, you will get the bonus again.",
     "concentration": true
   },
+  {
+    "name": "Control Force",
+    "level": 2,
+    "school": "Force",
+    "automation": [
+      {
+        "type": "target",
+        "target": "each",
+        "effects": [
+          {
+            "type": "ieffect2",
+            "name": "Immune to Spell Damage from {caster.name}.",
+            "duration": 1,
+            "end": 1,
+            "tick_on_caster": 1
+          }
+        ]
+     },
+     {
+      "type": "text",
+      "text": "You harness discipline to prevent damage to unwanted targets of your force powers. Choose a number of creatures within range up to your forcecasting modifier (minimum of one). Until the end of your next turn, those creatures take no damage from force powers you cast."
+     }
+    ],
+    "classes": "Light",
+    "subclasses": "",
+    "casttime": "1 action",
+    "range": "30 ft",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "1 round",
+    "ritual": false,
+    "description": "You harness discipline to prevent damage to unwanted targets of your force powers. Choose a number of creatures within range up to your forcecasting modifier (minimum of one). Until the end of your next turn, those creatures take no damage from force powers you cast.", 
+    "concentration": false
+  },
+  {
+    "name": "Force Grip",
+    "level": 2,
+    "school": "Force",
+    "classes": "Dark",
+    "subclasses": "",
+    "casttime": "1 action",
+    "range": "30 ft",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "Concentration, up to 1 minute",
+    "ritual": false,
+    "description": "You reach out with the Force and attempt to throttle a creature you can see within range that breathes. The creature must be Medium or smaller. At the start of its next turn, the target must make a Constitution saving throw. On a failed save, the target gains a level of slowed and begins to suffocate for the duration of the power. While suffocating, the target can still speak, but only falteringly. The target can repeat the save at the start of each of its turns, ending this power on itself on a successful save. The power also ends for an affected creature if it is ever outside the power's range.\n\nYou must use your action on each of your subsequent turns to continue this power. If you use your action to do anything else, the power ends.\n\n**Force Potency.** When you cast this power using a force slot of 4th level or higher, the target gains an additional level of slowed for every two slot levels above 2nd.",
+    "concentration": true
+  },
 

--- a/Homebrew/Resolute Spellbook/firstdaybreak-additions
+++ b/Homebrew/Resolute Spellbook/firstdaybreak-additions
@@ -532,7 +532,7 @@
     "automation": [
       {
         "type": "roll",
-        "dice": "3d6+{caster.spellbook.spell_mod} [healing]",
+        "dice": "2d8+{caster.spellbook.spell_mod} [healing]",
         "name": "healing"
       },
       {

--- a/Homebrew/Resolute Spellbook/firstdaybreak-additions
+++ b/Homebrew/Resolute Spellbook/firstdaybreak-additions
@@ -447,4 +447,120 @@
     "description": "You reach out with the Force and attempt to throttle a creature you can see within range that breathes. The creature must be Medium or smaller. At the start of its next turn, the target must make a Constitution saving throw. On a failed save, the target gains a level of slowed and begins to suffocate for the duration of the power. While suffocating, the target can still speak, but only falteringly. The target can repeat the save at the start of each of its turns, ending this power on itself on a successful save. The power also ends for an affected creature if it is ever outside the power's range.\n\nYou must use your action on each of your subsequent turns to continue this power. If you use your action to do anything else, the power ends.\n\n**Force Potency.** When you cast this power using a force slot of 4th level or higher, the target gains an additional level of slowed for every two slot levels above 2nd.",
     "concentration": true
   },
-
+  {
+    "name": "Force Lift",
+    "level": 2,
+    "school": "Force",
+    "classes": "Universal",
+    "subclasses": "",
+    "casttime": "1 action",
+    "range": "60 ft",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "Concentration, up to 10 minutes",
+    "ritual": false,
+    "description": "One creature or loose object of your choice that you can see within range rises vertically, up to 20 feet, and remains suspended there for the duration. This power can levitate a target that weighs up to 500 pounds. An unwilling creature that succeeds on a Constitution saving throw is unaffected.\n\nThe target can move only by pushing or pulling against a fixed object or surface within reach (such as a wall or a ceiling), which allows it to move as if it were climbing. You can change the target's altitude by up to 20 feet in either direction on your turn. If you are the target, you can move up or down as part of your move. Otherwise, you can use your action to move the target, which must remain within the power's range.\n\nWhen the power ends, the target floats gently to the ground if it is still aloft.",
+    "concentration": true
+  },
+  {
+    "name": "Force Listening",
+    "level": 2,
+    "school": "Force",
+    "classes": "Universal",
+    "subclasses": "",
+    "casttime": "1 action",
+    "range": "Self",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "Concentration, up to 10 minutes",
+    "ritual": false,
+    "description": "You use the Force to extend your senses through the earth. For the duration, while you remain on the ground, you gain the following benefits:\n\n- You cannot be deafened.\n- You have advantage on Wisdom (Perception) checks that rely on hearing.\n- You gain tremorsense out to 60 feet. Using tremorsense, you can detect and pinpoint the origin of vibrations within a specific radius, provided you and the source of the vibrations are in contact with the same ground or substance. Tremorsense can’t be used to detect flying or incorporeal creatures. In addition, you can clearly hear the speech of any creature you detect in this manner.",
+    "concentration": true
+  },
+  {
+    "name": "Forked Lightning",
+    "level": 2,
+    "school": "Force",
+    "classes": "Dark",
+    "subclasses": "",
+    "casttime": "1 action",
+    "range": "60ft",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "Instantaneous",
+    "ritual": false,
+    "description": "You create three arcs of lightning that streak toward targets of your choice within range. Make a ranged force attack for each arc. On a hit, the target takes 1d12 lightning damage. If two or more arcs hit the same target, it must make a Constitution saving throw. On a failed save, it becomes shocked until the end of its next turn.\n\n**Force Potency.** When you cast this power using a force slot of 3rd level or higher, you create two additional bolts for each slot level above 2nd.",
+    "concentration": false
+  },
+{
+    "name": "Freedom of Will",
+    "level": 2,
+    "school": "Force",
+    "automation": [
+      {
+        "type": "text",
+        "text": "You touch a creature and end one mind-affecting condition afflicting it. The condition can be frightened, charmed, paralyzed, or stunned. This power has no effect on droids or constructs."
+      }
+    ],
+    "classes": "Light",
+    "subclasses": "",
+    "casttime": "1 action",
+    "range": "Touch",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "Instantaneous",
+    "ritual": false,
+    "description": "You touch a creature and end one mind-affecting condition afflicting it. The condition can be frightened, charmed, paralyzed, or stunned. This power has no effect on droids or constructs.",
+    "concentration": false
+  },
+  {
+    "name": "Healing Meditation",
+    "level": 2,
+    "school": "Force",
+    "automation": [
+      {
+        "type": "roll",
+        "dice": "3d6+{caster.spellbook.spell_mod} [healing]",
+        "name": "healing"
+      },
+      {
+        "type": "target",
+        "target": "each",
+        "effects": [
+          {
+            "type": "damage",
+            "damage": "-{{healing}}"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "Up to six creatures of your choice that you can see within range each regain hit points equal to 2d8 + your forcecasting ability modifier. This power has no effect on droids or constructs."
+      }
+    ],
+    "classes": "Light",
+    "subclasses": "",
+    "casttime": "10 minutes",
+    "range": "30ft",
+    "components": {
+      "verbal": false,
+      "somatic": false,
+      "material": ""
+    },
+    "duration": "Instantaneous",
+    "ritual": false,
+    "description": "Up to six creatures of your choice that you can see within range each regain hit points equal to 2d8 + your forcecasting ability modifier. This power has no effect on droids or constructs.",
+    "concentration": false
+  }

--- a/Homebrew/Resolute Spellbook/firstdaybreak-additions.json
+++ b/Homebrew/Resolute Spellbook/firstdaybreak-additions.json
@@ -34,8 +34,7 @@
                                     {
                                         "automation": [
                                             {
-                                                "type": "remove_ieffect",
-                                                "removeParent": "if_no_children"
+                                                "type": "remove_ieffect"
                                             }
                                         ],
                                         "label": "Defends Shatterpoint - Remove Effect",
@@ -52,8 +51,7 @@
                                     {
                                         "automation": [
                                             {
-                                                "type": "remove_ieffect",
-                                                "removeParent": "if_no_children"
+                                                "type": "remove_ieffect"
                                             }
                                         ],
                                         "label": "Attacks Shatterpoint - Remove Effect",
@@ -374,195 +372,5 @@
         "ritual": false,
         "description": "The next time you hit with a melee weapon attack during this power’s duration, your attack deals an extra 1d6 psychic damage. Additionally, if the target is not a droid or construct, it must make a Wisdom saving throw or be frightened of you until the power ends. As an action, the creature can make a Wisdom check against your force save DC to steel its resolve and end this power.",
         "concentration": true
-    },
-    {
-        "name": "Channel Pain",
-        "level": 2,
-        "school": "Force",
-        "classes": "Dark",
-        "subclasses": "",
-        "casttime": "1 bonus action",
-        "range": "Self",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "Concentration, up to 1 minute",
-        "ritual": false,
-        "description": "You draw power from your pain. If you have taken 15 or more damage since the end of your last turn, you gain advantage on melee attack rolls and saving throws. Damage to temporary hit points is not included in this calculation. This benefit lasts until the start of your next turn. For the duration of the power, if you start your turn having taken 15 points of damage since the end of your last turn, you will get the bonus again.",
-        "concentration": true
-    },
-    {
-        "name": "Control Force",
-        "level": 2,
-        "school": "Force",
-        "automation": [
-            {
-                "type": "target",
-                "target": "each",
-                "effects": [
-                    {
-                        "type": "ieffect2",
-                        "name": "Immune to Spell Damage from {caster.name}.",
-                        "duration": 1,
-                        "end": 1,
-                        "tick_on_caster": 1
-                    }
-                ]
-            },
-            {
-                "type": "text",
-                "text": "You harness discipline to prevent damage to unwanted targets of your force powers. Choose a number of creatures within range up to your forcecasting modifier (minimum of one). Until the end of your next turn, those creatures take no damage from force powers you cast."
-            }
-        ],
-        "classes": "Light",
-        "subclasses": "",
-        "casttime": "1 action",
-        "range": "30 ft",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "1 round",
-        "ritual": false,
-        "description": "You harness discipline to prevent damage to unwanted targets of your force powers. Choose a number of creatures within range up to your forcecasting modifier (minimum of one). Until the end of your next turn, those creatures take no damage from force powers you cast.",
-        "concentration": false
-    },
-    {
-        "name": "Force Grip",
-        "level": 2,
-        "school": "Force",
-        "classes": "Dark",
-        "subclasses": "",
-        "casttime": "1 action",
-        "range": "30 ft",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "Concentration, up to 1 minute",
-        "ritual": false,
-        "description": "You reach out with the Force and attempt to throttle a creature you can see within range that breathes. The creature must be Medium or smaller. At the start of its next turn, the target must make a Constitution saving throw. On a failed save, the target gains a level of slowed and begins to suffocate for the duration of the power. While suffocating, the target can still speak, but only falteringly. The target can repeat the save at the start of each of its turns, ending this power on itself on a successful save. The power also ends for an affected creature if it is ever outside the power's range.\n\nYou must use your action on each of your subsequent turns to continue this power. If you use your action to do anything else, the power ends.\n\n**Force Potency.** When you cast this power using a force slot of 4th level or higher, the target gains an additional level of slowed for every two slot levels above 2nd.",
-        "concentration": true
-    },
-    {
-        "name": "Force Lift",
-        "level": 2,
-        "school": "Force",
-        "classes": "Universal",
-        "subclasses": "",
-        "casttime": "1 action",
-        "range": "60 ft",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "Concentration, up to 10 minutes",
-        "ritual": false,
-        "description": "One creature or loose object of your choice that you can see within range rises vertically, up to 20 feet, and remains suspended there for the duration. This power can levitate a target that weighs up to 500 pounds. An unwilling creature that succeeds on a Constitution saving throw is unaffected.\n\nThe target can move only by pushing or pulling against a fixed object or surface within reach (such as a wall or a ceiling), which allows it to move as if it were climbing. You can change the target's altitude by up to 20 feet in either direction on your turn. If you are the target, you can move up or down as part of your move. Otherwise, you can use your action to move the target, which must remain within the power's range.\n\nWhen the power ends, the target floats gently to the ground if it is still aloft.",
-        "concentration": true
-    },
-    {
-        "name": "Force Listening",
-        "level": 2,
-        "school": "Force",
-        "classes": "Universal",
-        "subclasses": "",
-        "casttime": "1 action",
-        "range": "Self",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "Concentration, up to 10 minutes",
-        "ritual": false,
-        "description": "You use the Force to extend your senses through the earth. For the duration, while you remain on the ground, you gain the following benefits:\n\n- You cannot be deafened.\n- You have advantage on Wisdom (Perception) checks that rely on hearing.\n- You gain tremorsense out to 60 feet. Using tremorsense, you can detect and pinpoint the origin of vibrations within a specific radius, provided you and the source of the vibrations are in contact with the same ground or substance. Tremorsense can’t be used to detect flying or incorporeal creatures. In addition, you can clearly hear the speech of any creature you detect in this manner.",
-        "concentration": true
-    },
-    {
-        "name": "Forked Lightning",
-        "level": 2,
-        "school": "Force",
-        "classes": "Dark",
-        "subclasses": "",
-        "casttime": "1 action",
-        "range": "60ft",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "Instantaneous",
-        "ritual": false,
-        "description": "You create three arcs of lightning that streak toward targets of your choice within range. Make a ranged force attack for each arc. On a hit, the target takes 1d12 lightning damage. If two or more arcs hit the same target, it must make a Constitution saving throw. On a failed save, it becomes shocked until the end of its next turn.\n\n**Force Potency.** When you cast this power using a force slot of 3rd level or higher, you create two additional bolts for each slot level above 2nd.",
-        "concentration": false
-    },
-    {
-        "name": "Freedom of Will",
-        "level": 2,
-        "school": "Force",
-        "automation": [
-            {
-                "type": "text",
-                "text": "You touch a creature and end one mind-affecting condition afflicting it. The condition can be frightened, charmed, paralyzed, or stunned. This power has no effect on droids or constructs."
-            }
-        ],
-        "classes": "Light",
-        "subclasses": "",
-        "casttime": "1 action",
-        "range": "Touch",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "Instantaneous",
-        "ritual": false,
-        "description": "You touch a creature and end one mind-affecting condition afflicting it. The condition can be frightened, charmed, paralyzed, or stunned. This power has no effect on droids or constructs.",
-        "concentration": false
-    },
-    {
-        "name": "Healing Meditation",
-        "level": 2,
-        "school": "Force",
-        "automation": [
-            {
-                "type": "roll",
-                "dice": "2d8+{caster.spellbook.spell_mod} [healing]",
-                "name": "healing"
-            },
-            {
-                "type": "target",
-                "target": "each",
-                "effects": [
-                    {
-                        "type": "damage",
-                        "damage": "-{{healing}}"
-                    }
-                ]
-            },
-            {
-                "type": "text",
-                "text": "Up to six creatures of your choice that you can see within range each regain hit points equal to 2d8 + your forcecasting ability modifier. This power has no effect on droids or constructs."
-            }
-        ],
-        "classes": "Light",
-        "subclasses": "",
-        "casttime": "10 minutes",
-        "range": "30ft",
-        "components": {
-            "verbal": false,
-            "somatic": false,
-            "material": ""
-        },
-        "duration": "Instantaneous",
-        "ritual": false,
-        "description": "Up to six creatures of your choice that you can see within range each regain hit points equal to 2d8 + your forcecasting ability modifier. This power has no effect on droids or constructs.",
-        "concentration": false
     }
 ]

--- a/Homebrew/Resolute Spellbook/spellbook.json
+++ b/Homebrew/Resolute Spellbook/spellbook.json
@@ -10919,7 +10919,7 @@
     "concentration": false
   },
   {
-    "name": "Judgement",
+    "name": "Judgment",
     "level": 0,
     "school": "Force",
     "classes": "Light",


### PR DESCRIPTION
gvars done for levels 2 and 3, text for one fourth of those spells added so far. 